### PR TITLE
New lazy routers

### DIFF
--- a/lib/munge.rb
+++ b/lib/munge.rb
@@ -1,4 +1,5 @@
 require "fileutils"
+require "forwardable"
 require "pathname"
 require "set"
 require "yaml"

--- a/lib/munge/core/router.rb
+++ b/lib/munge/core/router.rb
@@ -1,13 +1,22 @@
+require_relative "router/itemish"
+
 module Munge
   module Core
     class Router
       def initialize(alterant:)
-        @registry = []
+        @registries = { route: [], filepath: [] }
         @alterant = alterant
       end
 
       def register(router)
-        @registry.push(router)
+        case router.type
+        when :route
+          @registries[:route].push(router)
+        when :filepath
+          @registries[:filepath].push(router)
+        else
+          fail "invalid router"
+        end
       end
 
       def route(item)
@@ -16,23 +25,28 @@ module Munge
       end
 
       def filepath(item)
-        path = route_mapper(item, :filepath)
+        initial_route = route(item)
+        path = route_mapper(item, :filepath, initial_route)
         Util::Path.ensure_relpath(path)
       end
 
       private
 
-      def route_mapper(item, method_name)
-        fail "item has no route" unless item.route
-        fail "no routers are registered" if @registry.empty?
+      def route_mapper(item, method_name, initial_route = nil)
+        if !item.route && !initial_route
+          fail "item has no route"
+        end
 
+        itemish = Itemish.new(item, @alterant)
+
+        # FIXME: There is a circular dependency. Make transforming lazy
         content = @alterant.transform(item)
 
-        @registry
-          .select { |router| router.public_methods(false).include?(method_name) }
-          .inject(item.route) do |route, router|
-            if router.match?(route, content, item)
-              router.public_send(method_name, route, content, item)
+        @registries[method_name]
+          .select { |router| router.type == method_name }
+          .inject(initial_route || item.route) do |route, router|
+            if router.match?(route, itemish)
+              router.call(route, itemish)
             else
               route
             end

--- a/lib/munge/core/router.rb
+++ b/lib/munge/core/router.rb
@@ -39,9 +39,6 @@ module Munge
 
         itemish = Itemish.new(item, @alterant)
 
-        # FIXME: There is a circular dependency. Make transforming lazy
-        content = @alterant.transform(item)
-
         @registries[method_name]
           .select { |router| router.type == method_name }
           .inject(initial_route || item.route) do |route, router|

--- a/lib/munge/core/router/itemish.rb
+++ b/lib/munge/core/router/itemish.rb
@@ -1,0 +1,22 @@
+module Munge
+  module Core
+    class Router
+      class Itemish
+        extend Forwardable
+
+        def initialize(item, alterant)
+          @item     = item
+          @alterant = alterant
+        end
+
+        def compiled_content
+          @compiled_content ||= @alterant.transform(@item)
+        end
+
+        def_delegators :@item, *%i(type relpath id frontmatter stat layout)
+        def_delegators :@item, *%i(dirname filename basename extensions)
+        def_delegators :@item, *%i(relpath? route?)
+      end
+    end
+  end
+end

--- a/lib/munge/routers/add_index_html.rb
+++ b/lib/munge/routers/add_index_html.rb
@@ -6,11 +6,15 @@ module Munge
         @index           = index
       end
 
-      def match?(initial_route, _content, item)
+      def type
+        :filepath
+      end
+
+      def match?(initial_route, item)
         item_is_html?(item) && route_needs_extension?(initial_route)
       end
 
-      def filepath(initial_route, _content, _item)
+      def call(initial_route, _item)
         File.join(initial_route, @index)
       end
 

--- a/lib/munge/routers/auto_add_extension.rb
+++ b/lib/munge/routers/auto_add_extension.rb
@@ -5,15 +5,15 @@ module Munge
         @keep_extensions = keep_extensions
       end
 
-      def match?(initial_route, _content, item)
+      def type
+        :route
+      end
+
+      def match?(initial_route, item)
         item_should_have_extension?(item) && route_doesnt_have_extension?(initial_route)
       end
 
-      def route(initial_route, _content, item)
-        add_extension(initial_route, item)
-      end
-
-      def filepath(initial_route, _content, item)
+      def call(initial_route, item)
         add_extension(initial_route, item)
       end
 

--- a/lib/munge/routers/fingerprint.rb
+++ b/lib/munge/routers/fingerprint.rb
@@ -7,7 +7,11 @@ module Munge
         @separator  = separator
       end
 
-      def match?(_initial_route, _content, item)
+      def type
+        :route
+      end
+
+      def match?(_initial_route, item)
         if item.frontmatter.key?(:fingerprint_asset)
           return item.frontmatter[:fingerprint_asset]
         end
@@ -21,12 +25,12 @@ module Munge
         end
       end
 
-      def route(initial_route, content, _item)
-        generate_link(initial_route, content)
+      def call(initial_route, item)
+        generate_link(initial_route, item.compiled_content)
       end
 
-      def filepath(initial_route, content, _item)
-        generate_link(initial_route, content)
+      def filepath(initial_route, item)
+        generate_link(initial_route, item.compiled_content)
       end
 
       private

--- a/lib/munge/routers/fingerprint.rb
+++ b/lib/munge/routers/fingerprint.rb
@@ -29,10 +29,6 @@ module Munge
         generate_link(initial_route, item.compiled_content)
       end
 
-      def filepath(initial_route, item)
-        generate_link(initial_route, item.compiled_content)
-      end
-
       private
 
       def generate_link(initial_route, content)

--- a/lib/munge/routers/fingerprint.rb
+++ b/lib/munge/routers/fingerprint.rb
@@ -2,7 +2,7 @@ module Munge
   module Router
     class Fingerprint
       def initialize(extensions:,
-                     separator: "--")
+                     separator:)
         @extensions = extensions
         @separator  = separator
       end

--- a/lib/munge/routers/remove_index_basename.rb
+++ b/lib/munge/routers/remove_index_basename.rb
@@ -7,15 +7,15 @@ module Munge
         @index_basename  = Munge::Util::Path.basename_no_extension(@index)
       end
 
-      def match?(initial_route, _content, item)
+      def type
+        :route
+      end
+
+      def match?(initial_route, item)
         item_is_html?(item) && basename_is_index?(initial_route)
       end
 
-      def route(initial_route, _content, _item)
-        Munge::Util::Path.dirname(initial_route)
-      end
-
-      def filepath(initial_route, _content, _item)
+      def call(initial_route, _item)
         Munge::Util::Path.dirname(initial_route)
       end
 

--- a/seeds/setup.rb
+++ b/seeds/setup.rb
@@ -8,7 +8,7 @@ tilt_transformer.register(Munge::Helper::Rendering)
 
 system.alterant.register(tilt_transformer)
 
-system.router.register(Router::Fingerprint.new(extensions: system.config[:keep_extensions]))
+system.router.register(Router::Fingerprint.new(extensions: system.config[:keep_extensions], separator: system.config[:fingeprint_separator]))
 system.router.register(Router::RemoveIndexBasename.new(html_extensions: system.config[:text_extensions], index: system.config[:index]))
 system.router.register(Router::AddIndexHtml.new(html_extensions: system.config[:text_extensions], index: system.config[:index]))
 system.router.register(Router::AutoAddExtension.new(keep_extensions: system.config[:keep_extensions]))

--- a/test/core__router__itemish_test.rb
+++ b/test/core__router__itemish_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class CoreRouterItemishTest < Minitest::Test
+  def test_compiled_content
+    item = OpenStruct.new
+
+    alterant = Minitest::Mock.new
+    alterant.expect(:transform, "postcompile", [item])
+
+    itemish = Munge::Core::Router::Itemish.new(item, alterant)
+    itemish.compiled_content
+
+    alterant.verify
+  end
+
+  def test_delegated_method
+    item = Minitest::Mock.new
+    item.expect(:frontmatter, {})
+
+    alterant =
+      QuickDummy.new(
+        transform: -> (_item) { "postcompile" }
+      )
+
+    itemish = Munge::Core::Router::Itemish.new(item, alterant)
+    itemish.frontmatter
+
+    item.verify
+  end
+end

--- a/test/core__router_test.rb
+++ b/test/core__router_test.rb
@@ -17,63 +17,39 @@ class CoreRouterTest < Minitest::Test
   end
 
   def register_dummy_router!
-    @dummy_router = Object.new
-
-    def @dummy_router.match?(*)
-      true
-    end
-
-    def @dummy_router.route(*)
-      "/dummy/route"
-    end
-
-    def @dummy_router.filepath(*)
-      "dummy/route/index.html"
-    end
+    @dummy_router =
+      QuickDummy.new(
+        match?: -> (*) { true },
+        route: -> (*) { "dummy/route" },
+        filepath: -> (*) { "dummy/route/index.html" },
+      )
 
     @router.register(@dummy_router)
   end
 
   def register_dummy_rot13_router!
-    @rot13_router = Object.new
-
-    def @rot13_router.match?(*)
-      true
-    end
-
-    def @rot13_router.route(route, *)
-      route.tr("a-z", "n-za-m")
-    end
-
-    def @rot13_router.filepath(route, *)
-      route.tr("a-z", "n-za-m")
-    end
+    @rot13_router =
+      QuickDummy.new(
+        match?: -> (*) { true },
+        route: -> (route, *) { route.tr("a-z", "n-za-m") },
+        filepath: -> (route, *) { route.tr("a-z", "n-za-m") }
+      )
 
     @router.register(@rot13_router)
   end
 
   def register_dummy_duplicate_only_route_router!
-    @duplicate_router = Object.new
-
-    def @duplicate_router.match?(*)
-      true
-    end
-
-    def @duplicate_router.filepath(route, *)
-      route + route
-    end
+    @duplicate_router =
+      QuickDummy.new(
+        match?: -> (*) { true },
+        filepath: -> (route, *) { route + route }
+      )
 
     @router.register(@duplicate_router)
   end
 
   def new_dummy_alterant
-    alterant = Object.new
-
-    def alterant.transform(*)
-      "dummy transformed text"
-    end
-
-    alterant
+    QuickDummy.new(transform: -> (*) { "dummy transformed text" })
   end
 
   def test_route_single_router

--- a/test/core__router_test.rb
+++ b/test/core__router_test.rb
@@ -123,4 +123,28 @@ class CoreRouterTest < Minitest::Test
     # Filepath's basename should be: rot1
     assert_equal "riaam/fcihs/joefy.iunm", @router.filepath(item)
   end
+
+  def test_registering_invalid_router
+    bad_router =
+      QuickDummy.new(
+        type: -> { :invalid },
+        match?: -> (*) { true },
+        call: -> { "" }
+      )
+
+    assert_raises do
+      @router.register(bad_router)
+    end
+  end
+
+  def test_routing_item_with_no_route
+    item       = new_item
+    item.route = nil
+
+    register_dummy_router!
+
+    assert_raises do
+      @router.route(item)
+    end
+  end
 end

--- a/test/integration__router_test.rb
+++ b/test/integration__router_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class IntegrationRouterTest < Minitest::Test
   def setup
-    fingerprint = Munge::Router::Fingerprint.new(extensions: %w(gif))
+    fingerprint = Munge::Router::Fingerprint.new(extensions: %w(gif), separator: "--")
     index_basename = Munge::Router::RemoveIndexBasename.new(html_extensions: %w(html), index: "index.html")
     index_html = Munge::Router::AddIndexHtml.new(html_extensions: %w(html), index: "index.html")
     auto_add_extension = Munge::Router::AutoAddExtension.new(keep_extensions: %w(gif))

--- a/test/router__add_index_html_test.rb
+++ b/test/router__add_index_html_test.rb
@@ -9,25 +9,29 @@ class RouterAddIndexHtmlTest < Minitest::Test
       )
   end
 
+  def test_only_for_filepath
+    assert_equal :filepath, @index_html.type
+  end
+
   def test_match_html
     item = OpenStruct.new
     item.extensions = %w(html erb)
 
-    assert_equal true, @index_html.match?("about", "", item)
-    assert_equal false, @index_html.match?("about.htm", "", item)
+    assert_equal true, @index_html.match?("about", item)
+    assert_equal false, @index_html.match?("about.htm", item)
   end
 
   def test_match_not_html
     item = OpenStruct.new
     item.extensions = %w(gif erb)
 
-    assert_equal false, @index_html.match?("about", "", item)
-    assert_equal false, @index_html.match?("about.htm", "", item)
+    assert_equal false, @index_html.match?("about", item)
+    assert_equal false, @index_html.match?("about.htm", item)
   end
 
   def test_route_without_hashing_because_of_extension
     item = Object.new
 
-    assert_equal "about/index.html", @index_html.filepath("about", "", item)
+    assert_equal "about/index.html", @index_html.call("about", item)
   end
 end

--- a/test/router__auto_add_extension_test.rb
+++ b/test/router__auto_add_extension_test.rb
@@ -12,29 +12,22 @@ class RouterAutoAddExtensionTest < Minitest::Test
   def test_match_gif_item
     gif_item = new_fake_item(exts: %w(gif))
 
-    assert_equal true, @auto_add_extension.match?("foo", "", gif_item)
-    assert_equal false, @auto_add_extension.match?("foo.gif", "", gif_item)
+    assert_equal true, @auto_add_extension.match?("foo", gif_item)
+    assert_equal false, @auto_add_extension.match?("foo.gif", gif_item)
   end
 
   def test_match_txt_item
     txt_item = new_fake_item(exts: %w(txt erb))
 
-    assert_equal false, @auto_add_extension.match?("foo", "", txt_item)
-    assert_equal false, @auto_add_extension.match?("foo.txt", "", txt_item)
-    assert_equal false, @auto_add_extension.match?("foo.gif", "", txt_item)
+    assert_equal false, @auto_add_extension.match?("foo", txt_item)
+    assert_equal false, @auto_add_extension.match?("foo.txt", txt_item)
+    assert_equal false, @auto_add_extension.match?("foo.gif", txt_item)
   end
 
-  def test_route
+  def test_call
     gif_item = new_fake_item(exts: %w(gif))
 
-    assert_equal "foo.gif", @auto_add_extension.route("foo", "", gif_item)
-    assert_equal "foo.txt.gif", @auto_add_extension.route("foo.txt", "", gif_item)
-  end
-
-  def test_filepath
-    gif_item = new_fake_item(exts: %w(gif))
-
-    assert_equal "foo.gif", @auto_add_extension.filepath("foo", "", gif_item)
-    assert_equal "foo.txt.gif", @auto_add_extension.filepath("foo.txt", "", gif_item)
+    assert_equal "foo.gif", @auto_add_extension.call("foo", gif_item)
+    assert_equal "foo.txt.gif", @auto_add_extension.call("foo.txt", gif_item)
   end
 end

--- a/test/router__fingerprint_test.rb
+++ b/test/router__fingerprint_test.rb
@@ -2,61 +2,59 @@ require "test_helper"
 
 class RouterFingerprintTest < Minitest::Test
   def setup
-    @fingerprint = Munge::Router::Fingerprint.new(extensions: %w(gif))
+    @fingerprint = Munge::Router::Fingerprint.new(extensions: %w(gif), separator: "--")
   end
 
-  def new_fake_item
-    OpenStruct.new(frontmatter: {})
+  def new_fake_itemish
+    OpenStruct.new(frontmatter: {}, compiled_content: "")
   end
 
   def test_match_false_because_frontmatter
-    item = new_fake_item
+    item = new_fake_itemish
     item.frontmatter[:fingerprint_asset] = false
 
-    assert_equal false, @fingerprint.match?("cool", "", item)
+    assert_equal false, @fingerprint.match?("cool", item)
   end
 
   def test_match_true_because_frontmatter
-    item = new_fake_item
+    item = new_fake_itemish
     item.frontmatter[:fingerprint_asset] = true
 
-    assert_equal true, @fingerprint.match?("cool", "", item)
+    assert_equal true, @fingerprint.match?("cool", item)
   end
 
   def test_match_because_extension
-    gif_item = new_fake_item
+    gif_item = new_fake_itemish
     gif_item.extensions = %w(gif)
 
-    assert_equal true, @fingerprint.match?("cool", "", gif_item)
+    assert_equal true, @fingerprint.match?("cool", gif_item)
   end
 
   def test_match_false_because_extension
-    txt_item = new_fake_item
+    txt_item = new_fake_itemish
     txt_item.extensions = %w(txt)
 
-    assert_equal false, @fingerprint.match?("cool", "", txt_item)
+    assert_equal false, @fingerprint.match?("cool", txt_item)
   end
 
   def test_fingerprinted_route_and_filepath
-    item = new_fake_item
+    item = new_fake_itemish
 
-    assert_equal "transparent--#{fingerprint}.gif", @fingerprint.route("transparent.gif", "", item)
-    assert_equal "transparent--#{fingerprint}.gif", @fingerprint.filepath("transparent.gif", "", item)
+    assert_equal "transparent--#{fingerprint}.gif", @fingerprint.call("transparent.gif", item)
   end
 
   def test_fingerprinted_route_and_filepath_with_no_extension
-    item = new_fake_item
+    item = new_fake_itemish
 
-    assert_equal "transparent--#{fingerprint}", @fingerprint.route("transparent", "", item)
-    assert_equal "transparent--#{fingerprint}", @fingerprint.filepath("transparent", "", item)
+    assert_equal "transparent--#{fingerprint}", @fingerprint.call("transparent", item)
   end
 
   def test_independence_of_route_and_filepath_and_itemroute
-    item = new_fake_item
+    item = new_fake_itemish
     item.route = "transparent"
 
-    assert_equal "foo--#{fingerprint}", @fingerprint.route("foo", "", item)
-    assert_equal "bar--#{fingerprint}.gif", @fingerprint.filepath("bar.gif", "", item)
+    assert_equal "foo--#{fingerprint}", @fingerprint.call("foo", item)
+    assert_equal "bar--#{fingerprint}", @fingerprint.call("bar", item)
   end
 
   private

--- a/test/router__fingerprint_test.rb
+++ b/test/router__fingerprint_test.rb
@@ -37,13 +37,13 @@ class RouterFingerprintTest < Minitest::Test
     assert_equal false, @fingerprint.match?("cool", txt_item)
   end
 
-  def test_fingerprinted_route_and_filepath
+  def test_fingerprinted_with_route_with_extension
     item = new_fake_itemish
 
     assert_equal "transparent--#{fingerprint}.gif", @fingerprint.call("transparent.gif", item)
   end
 
-  def test_fingerprinted_route_and_filepath_with_no_extension
+  def test_fingerprinted_with_route_without_extension
     item = new_fake_itemish
 
     assert_equal "transparent--#{fingerprint}", @fingerprint.call("transparent", item)

--- a/test/router__remove_index_basename_test.rb
+++ b/test/router__remove_index_basename_test.rb
@@ -13,18 +13,18 @@ class RouterRemoveIndexBasenameTest < Minitest::Test
     item = OpenStruct.new
     item.extensions = %w(html erb)
 
-    assert_equal true, @index_remover.match?("index", "", item)
-    assert_equal false, @index_remover.match?("about", "", item)
+    assert_equal true, @index_remover.match?("index", item)
+    assert_equal false, @index_remover.match?("about", item)
 
-    assert_equal false, @index_remover.match?("index.htm", "", item)
-    assert_equal false, @index_remover.match?("index.html", "", item)
-    assert_equal false, @index_remover.match?("about.html", "", item)
+    assert_equal false, @index_remover.match?("index.htm", item)
+    assert_equal false, @index_remover.match?("index.html", item)
+    assert_equal false, @index_remover.match?("about.html", item)
   end
 
-  def test_route
+  def test_call
     item = Object.new
 
-    assert_equal "", @index_remover.route("index", "", item)
-    assert_equal "about", @index_remover.route("about/index", "", item)
+    assert_equal "", @index_remover.call("index", item)
+    assert_equal "about", @index_remover.call("about/index", item)
   end
 end

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -8,11 +8,6 @@ class RunnerTest < Minitest::Test
   end
 
   def test_missing_static_method
-    FakeFS do
-      FakeFS::FileSystem.clone(seeds_path)
-      @out, @err = capture_io { Munge::Runner.write(seeds_path) }
-    end
-
     assert_respond_to Munge::Runner, :write
     refute_respond_to Munge::Runner, :this_method_probably_doesnt_exist
   end

--- a/test/util__path_test.rb
+++ b/test/util__path_test.rb
@@ -38,5 +38,6 @@ class UtilPathTest < Minitest::Test
   def test_ensure_relpath
     assert_equal "foo/bar.", Munge::Util::Path.ensure_relpath("/foo/bar.")
     assert_equal "foo/bar", Munge::Util::Path.ensure_relpath("//foo//bar")
+    assert_equal "foo/bar", Munge::Util::Path.ensure_relpath("foo//bar")
   end
 end


### PR DESCRIPTION
- Routers now compile `item.content` lazily
  - In terms of bundled routers, only the Fingerprint router routes compiles the item
  - This allows for `item`s to be self-referencing
- Individual routers now work a little differently
  - `router.filepath(item)` first calls `router.route(item)`
  - Individual routers now require a method named `type`.
  - Routers with type `:route` are run for all routes
  - Routers with type `:filepath` are run _after_ all routers with type `:route`
- Fingerprint router now requires that `separator` config option is set