### PR TITLE
Specifically require SecureRandom

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,7 @@ require "tilt/redcarpet"
 require "sass"
 
 require "ostruct"
+require "securerandom"
 
 class QuickDummy
   def initialize(**args)


### PR DESCRIPTION
Some tests failed because of the missing required library, depending on how the tests were run.