### PR TITLE
Straightforward Item ID

### DIFF
--- a/lib/munge/system.rb
+++ b/lib/munge/system.rb
@@ -14,7 +14,7 @@ module Munge
       source_item_factory =
         ItemFactory.new(
           text_extensions: config[:text_extensions] + config[:bintext_extensions],
-          ignore_extensions: false
+          ignore_extensions: config[:dynamic_extensions]
         )
 
       layouts_item_factory =

--- a/lib/munge/system.rb
+++ b/lib/munge/system.rb
@@ -20,7 +20,7 @@ module Munge
       layouts_item_factory =
         ItemFactory.new(
           text_extensions: config[:text_extensions] + config[:bintext_extensions],
-          ignore_extensions: true
+          ignore_extensions: %w(.+)
         )
 
       @items =

--- a/lib/munge/system/item_factory.rb
+++ b/lib/munge/system/item_factory.rb
@@ -1,4 +1,5 @@
 require_relative "item_factory/content_parser"
+require_relative "item_factory/item_identifier"
 
 module Munge
   class System

--- a/lib/munge/system/item_factory.rb
+++ b/lib/munge/system/item_factory.rb
@@ -6,8 +6,8 @@ module Munge
     class ItemFactory
       def initialize(text_extensions:,
                      ignore_extensions:)
-        @text_extensions   = Set.new(text_extensions)
-        @ignore_extensions = ignore_extensions
+        @text_extensions = Set.new(text_extensions)
+        @item_identifier = Munge::System::ItemFactory::ItemIdentifier.new(remove_extensions: ignore_extensions)
       end
 
       def build(relpath:,
@@ -16,12 +16,7 @@ module Munge
                 stat: nil)
         type = compute_file_type(relpath)
 
-        id =
-          if @ignore_extensions || type == :text
-            compute_id(relpath)
-          else
-            relpath
-          end
+        id = @item_identifier.call(relpath)
 
         Munge::Item.new(
           relpath: relpath,
@@ -72,26 +67,6 @@ module Munge
         else
           :binary
         end
-      end
-
-      def compute_id(relpath)
-        dirname  = Munge::Util::Path.dirname(relpath)
-        basename =
-          if @ignore_extensions
-            Munge::Util::Path.basename_no_extension(relpath)
-          else
-            Munge::Util::Path.basename_one_extension(relpath)
-          end
-
-        id = []
-
-        unless dirname == ""
-          id.push(dirname)
-        end
-
-        id.push(basename)
-
-        id.join("/")
       end
     end
   end

--- a/lib/munge/system/item_factory/item_identifier.rb
+++ b/lib/munge/system/item_factory/item_identifier.rb
@@ -1,0 +1,38 @@
+module Munge
+  class System
+    class ItemFactory
+      class ItemIdentifier
+        def initialize(remove_extensions:)
+          @remove_extension_regex = join_regex_strings(remove_extensions)
+        end
+
+        def call(relpath)
+          dirname    = Munge::Util::Path.dirname(relpath)
+          basename   = Munge::Util::Path.basename_no_extension(relpath)
+          extensions = Munge::Util::Path.extnames(relpath)
+
+          filtered_extensions =
+            extensions
+              .map    { |ext| @remove_extension_regex.match(ext) || ext }
+              .select { |ext| ext.is_a?(String) }
+
+          new_basename =
+            [basename, *filtered_extensions].join(".")
+
+          Munge::Util::Path.join(dirname, new_basename)
+        end
+
+        private
+
+        def join_regex_strings(strings)
+          regexes =
+            strings
+              .map { |str| "\\A#{str}\\Z" }
+              .map { |str| Regexp.new(str) }
+
+          Regexp.union(regexes)
+        end
+      end
+    end
+  end
+end

--- a/lib/munge/util/path.rb
+++ b/lib/munge/util/path.rb
@@ -71,6 +71,12 @@ module Munge
           correct
         end
       end
+
+      def self.join(*path_components)
+        path_components
+          .reject { |component| component.empty? }
+          .join("/")
+      end
     end
   end
 end

--- a/lib/munge/util/path.rb
+++ b/lib/munge/util/path.rb
@@ -74,7 +74,7 @@ module Munge
 
       def self.join(*path_components)
         path_components
-          .reject { |component| component.empty? }
+          .reject(&:empty?)
           .join("/")
       end
     end

--- a/lib/munge/util/path.rb
+++ b/lib/munge/util/path.rb
@@ -17,6 +17,17 @@ module Munge
         end
       end
 
+      def self.extnames(path)
+        basename = File.basename(path)
+        basename_parts = basename.split(".")
+
+        basename_parts[1..-1]
+      end
+
+      def self.basename(path)
+        File.basename(path)
+      end
+
       def self.basename_one_extension(path)
         basename       = File.basename(path)
         basename_parts = basename.split(".")

--- a/seeds/config.yml
+++ b/seeds/config.yml
@@ -23,3 +23,7 @@ bin_extensions:
   - ttf
   - eot
   - woff
+dynamic_extensions:
+  - erb
+  - scss
+  - md

--- a/test/system__item_factory__item_identifier_test.rb
+++ b/test/system__item_factory__item_identifier_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class SystemItemFactoryItemIdentifierTest < Minitest::Test
+  def test_basename
+    identifier = Munge::System::ItemFactory::ItemIdentifier.new(remove_extensions: dynamic_extensions)
+
+    assert_equal "foo.bar.baz", identifier.call("foo.bar.baz.erb")
+    assert_equal "foo.erbrb", identifier.call("foo.erbrb")
+  end
+
+  def test_relpath
+    identifier = Munge::System::ItemFactory::ItemIdentifier.new(remove_extensions: dynamic_extensions)
+
+    assert_equal "foo/bar/foo.bar.baz", identifier.call("foo/bar/foo.bar.baz.erb")
+    assert_equal "bar/foo/foo.erbrb", identifier.call("bar/foo/foo.erbrb")
+  end
+
+  def test_remove_all
+    identifier = Munge::System::ItemFactory::ItemIdentifier.new(remove_extensions: remove_all_extensions)
+
+    assert_equal "foo", identifier.call("foo.bar.baz.erb")
+    assert_equal "bar/foo", identifier.call("bar/foo.erbrb")
+  end
+
+  private
+
+  def dynamic_extensions
+    %w(erb scss)
+  end
+
+  def remove_all_extensions
+    %w(.+)
+  end
+end

--- a/test/system__item_factory_test.rb
+++ b/test/system__item_factory_test.rb
@@ -5,7 +5,7 @@ class SystemItemFactoryTest < Minitest::Test
     # @item_factory = new_item_factory(ignored_basenames: %w(index dir))
     @item_factory = Munge::System::ItemFactory.new(
       text_extensions: %w(txt md html),
-      ignore_extensions: false
+      ignore_extensions: %w(erb)
     )
   end
 
@@ -36,7 +36,7 @@ class SystemItemFactoryTest < Minitest::Test
     item_factory =
       Munge::System::ItemFactory.new(
         text_extensions: %w(txt md html),
-        ignore_extensions: true
+        ignore_extensions: %w(.+)
       )
 
     item = item_factory.build(relpath: "index.html", content: "")

--- a/test/util__path_test.rb
+++ b/test/util__path_test.rb
@@ -49,4 +49,8 @@ class UtilPathTest < Minitest::Test
     assert_equal "foo/bar", Munge::Util::Path.ensure_relpath("//foo//bar")
     assert_equal "foo/bar", Munge::Util::Path.ensure_relpath("foo//bar")
   end
+
+  def test_join
+    assert_equal "foo/bar", Munge::Util::Path.join("foo", "", "bar")
+  end
 end

--- a/test/util__path_test.rb
+++ b/test/util__path_test.rb
@@ -15,6 +15,15 @@ class UtilPathTest < Minitest::Test
     assert_equal "", Munge::Util::Path.extname("ab.")
   end
 
+  def test_extnames
+    assert_equal %w(ij kl), Munge::Util::Path.extnames("ab.cd/ef/gh.ij.kl")
+  end
+
+  def test_basename
+    assert_equal "foo.rb", Munge::Util::Path.basename("foo.rb")
+    assert_equal "foo.rb", Munge::Util::Path.basename("bar/foo.rb")
+  end
+
   def test_basename_no_extension
     assert_equal "foo", Munge::Util::Path.basename_no_extension("foo.rb")
     assert_equal "bar", Munge::Util::Path.basename_no_extension("foo/bar.rb")


### PR DESCRIPTION
`Item#id` will be the relative path of the item, minus the "dynamic" extensions, such as `erb`, `haml`, `scss`, etc.

```ruby
"foo.html"     # => "foo.html"
"foo.erb"      # => "foo"
"foo.html.erb" # => "foo.html"
"foo.erberb"   # => "foo.erberb" (because erberb != erb)
```