### PR TITLE
Freeze list of items

### DIFF
--- a/lib/munge/init.rb
+++ b/lib/munge/init.rb
@@ -18,6 +18,7 @@ module Munge
       import(rules_path)
 
       @app.items.each(&:freeze)
+      @app.items.freeze
     end
 
     def config_path

--- a/lib/munge/system/collection.rb
+++ b/lib/munge/system/collection.rb
@@ -45,6 +45,12 @@ module Munge
         found_item
       end
 
+      def freeze
+        @items.freeze
+
+        super
+      end
+
       private
 
       def prune_args(args)

--- a/test/system__collection_test.rb
+++ b/test/system__collection_test.rb
@@ -88,4 +88,18 @@ class SystemCollectionTest < Minitest::Test
     assert_includes @items.each.to_a, item_params
     assert_equal "binary content lol", @items["id foo/bar.jpg"][:content]
   end
+
+  def test_freeze
+    @items.freeze
+
+    assert_raises(RuntimeError) do
+      @items.push(
+        @items.build(
+          relpath: "foo/bar.jpg",
+          content: "binary content lol",
+          frontmatter: {}
+        )
+      )
+    end
+  end
 end


### PR DESCRIPTION
I froze each individual item, but forgot to freeze the list of items.

**Note:**

I currently have two steps to freeze this list; one freezes the individual items, and the second freezes the array of items. The reason for this distinction is primarily because Ruby does not support any support of "deep freeze", and I don't want to create any surprises.