### PR TITLE
Item relpath in backtrace

### DIFF
--- a/lib/munge/helpers/rendering.rb
+++ b/lib/munge/helpers/rendering.rb
@@ -5,19 +5,21 @@ module Munge
         content   = content_override || item.content
         renderers = tilt_renderer_list(item, engines)
         mdata     = merged_data(item.frontmatter, data, self_item: item)
+        item_path = item.relpath
 
-        render_string(content, data: mdata, engines: renderers)
+        render_string(content, data: mdata, engines: renderers, template_name: item_path)
       end
 
       def layout(item_or_string, data: {}, &block)
         layout_item = resolve_layout(item_or_string)
         renderers   = tilt_renderer_list(layout_item, nil)
         mdata       = merged_data(layout_item.frontmatter, data, self_layout: layout_item)
+        layout_path = "(layout) #{layout_item.relpath}"
 
-        render_string(layout_item.content, data: mdata, engines: renderers, &block)
+        render_string(layout_item.content, data: mdata, engines: renderers, template_name: layout_path, &block)
       end
 
-      def render_string(content, data: {}, engines: [], &block)
+      def render_string(content, data: {}, engines: [], template_name: nil, &block)
         inner =
           if block_given?
             capture(&block)
@@ -26,7 +28,7 @@ module Munge
         output =
           engines
             .inject(content) do |memo, engine|
-              template = engine.new { memo }
+              template = engine.new(template_name) { memo }
 
               if inner
                 template.render(self, data) { inner }

--- a/lib/munge/system/router.rb
+++ b/lib/munge/system/router.rb
@@ -32,7 +32,7 @@ module Munge
 
       def route_mapper(item, method_name, initial_route = nil)
         if !item.route && !initial_route
-          raise "item has no route"
+          raise "item `#{item.relpath}` has no route"
         end
 
         itemish = Itemish.new(item, @alterant)


### PR DESCRIPTION
Specify the template name in the backtrace. This should help with general usability and debugging.

Also made an error message more specific by listing the item's relpath