### PR TITLE
Don't return Items where `route = false`

### DIFF
--- a/lib/munge/application.rb
+++ b/lib/munge/application.rb
@@ -13,7 +13,7 @@ module Munge
     end
 
     def routed
-      items.reject { |item| item.route.nil? }
+      items.select { |item| item.route }
     end
 
     def build_virtual_item(relpath, content, **frontmatter)

--- a/lib/munge/application.rb
+++ b/lib/munge/application.rb
@@ -13,7 +13,7 @@ module Munge
     end
 
     def routed
-      items.select { |item| item.route }
+      items.select(&:route)
     end
 
     def build_virtual_item(relpath, content, **frontmatter)

--- a/test/application_test.rb
+++ b/test/application_test.rb
@@ -56,4 +56,20 @@ class ApplicationTest < TestCase
     assert_instance_of Enumerator, enum_item
     assert_equal 1, enum_item.size
   end
+
+  test "items with false routes don't show up in #routed or #nonrouted" do
+    yes_item    = OpenStruct.new(route: "yes")
+    nil_item    = OpenStruct.new(route: nil)
+    false_item  = OpenStruct.new(route: false)
+    system      = OpenStruct.new(items: [yes_item, nil_item, false_item])
+    application = Munge::Application.new(system)
+
+    assert_includes(application.routed.map(&:route), "yes")
+    refute_includes(application.routed.map(&:route), nil)
+    refute_includes(application.routed.map(&:route), false)
+
+    refute_includes(application.nonrouted.map(&:route), "yes")
+    assert_includes(application.nonrouted.map(&:route), nil)
+    refute_includes(application.nonrouted.map(&:route), false)
+  end
 end


### PR DESCRIPTION
Items where routes are false shouldn't show up in:

- `Application#routed` because someone technically gave it a route
- `Application#nonrouted` because the route isn't truthy
