### PR TITLE
Asset tags

### DIFF
--- a/lib/munge/helpers/asset_tags.rb
+++ b/lib/munge/helpers/asset_tags.rb
@@ -10,7 +10,7 @@ module Munge
 
       def javascript_tag(basename, options = {})
         options[:type] = "text/javascript"
-        options[:src]  = javascript_url(basename)
+        options[:src]  = javascript_path(basename)
 
         content_tag(:script, options)
       end

--- a/lib/munge/helpers/asset_tags.rb
+++ b/lib/munge/helpers/asset_tags.rb
@@ -2,15 +2,15 @@ module Munge
   module Helpers
     module AssetTags
       def stylesheet_tag(basename, options = {})
-        options[:rel]  = "stylesheet"
-        options[:href] = stylesheet_path(basename)
+        options[:rel]  ||= "stylesheet"
+        options[:href] ||= stylesheet_path(basename)
 
         empty_tag(:link, options)
       end
 
       def javascript_tag(basename, options = {})
-        options[:type] = "text/javascript"
-        options[:src]  = javascript_path(basename)
+        options[:type] ||= "text/javascript"
+        options[:src]  ||= javascript_path(basename)
 
         content_tag(:script, options)
       end

--- a/lib/munge/helpers/asset_tags.rb
+++ b/lib/munge/helpers/asset_tags.rb
@@ -3,7 +3,7 @@ module Munge
     module AssetTags
       def stylesheet_tag(basename, options = {})
         options[:rel]  = "stylesheet"
-        options[:href] = stylesheet_url(basename)
+        options[:href] = stylesheet_path(basename)
 
         empty_tag(:link, options)
       end

--- a/test/helpers__asset_tags_test.rb
+++ b/test/helpers__asset_tags_test.rb
@@ -15,37 +15,37 @@ class HelpersAssetTagsTest < TestCase
     @renderer.extend(Munge::Helpers::Tag)
   end
 
-  def test_stylesheet_tag
+  test "#stylesheet_tag returns a tag with correct path and options" do
     tag = @renderer.stylesheet_tag("foo", class: "id")
 
     assert_equal %(<link class="id" rel="stylesheet" href="foo.css" />), tag
   end
 
-  def test_javascript_tag
+  test "#javascript_tag returns a tag with correct path and options" do
     tag = @renderer.javascript_tag("foo", id: "class")
 
     assert_equal %(<script id="class" type="text/javascript" src="foo.js"></script>), tag
   end
 
-  test "overrideable stylesheet rel and href" do
+  test "#stylesheet_tag has overrideable stylesheet rel and href" do
     tag = @renderer.stylesheet_tag("foo", rel: "stylesheet/less", href: "bar.less")
 
     assert_equal %(<link rel="stylesheet/less" href="bar.less" />), tag
   end
 
-  test "overrideable javascript type and src" do
+  test "#javascript_tag has overrideable javascript type and src" do
     tag = @renderer.javascript_tag("foo", type: "text/coffeescript", src: "bar.coffee")
 
     assert_equal %(<script type="text/coffeescript" src="bar.coffee"></script>), tag
   end
 
-  def test_inline_stylesheet_tag
+  test "#inline_stylesheet_tag returns contents of css around correct tags" do
     tag = @renderer.inline_stylesheet_tag("foo", id: "class")
 
     assert_equal %(<style id="class">rendered item</style>), tag
   end
 
-  def test_inline_javascript_tag
+  test "#inline_javascript_tag returns contents of js around correct tags" do
     tag = @renderer.inline_javascript_tag("foo", class: "id")
 
     assert_equal %(<script class="id">rendered item</script>), tag

--- a/test/helpers__asset_tags_test.rb
+++ b/test/helpers__asset_tags_test.rb
@@ -18,34 +18,24 @@ class HelpersAssetTagsTest < TestCase
   def test_stylesheet_tag
     tag = @renderer.stylesheet_tag("foo", class: "id")
 
-    assert_match %(<link), tag
-    assert_match %(class="id"), tag
-    assert_match %(rel="stylesheet" href="foo.css"), tag
-    assert_match %(/>), tag
+    assert_match %(<link class="id" rel="stylesheet" href="foo.css" />), tag
   end
 
   def test_javascript_tag
     tag = @renderer.javascript_tag("foo", id: "class")
 
-    assert_match %(<script), tag
-    assert_match %(id="class"), tag
-    assert_match %(type="text/javascript" src="foo.js"), tag
-    assert_match %(</script>), tag
+    assert_match %(<script id="class" type="text/javascript" src="foo.js"></script>), tag
   end
 
   def test_inline_stylesheet_tag
     tag = @renderer.inline_stylesheet_tag("foo", id: "class")
 
-    assert_match %(<style), tag
-    assert_match %(id="class"), tag
-    assert_match %(>rendered item</style>), tag
+    assert_match %(<style id="class">rendered item</style>), tag
   end
 
   def test_inline_javascript_tag
     tag = @renderer.inline_javascript_tag("foo", class: "id")
 
-    assert_match %(<script), tag
-    assert_match %(class="id"), tag
-    assert_match %(>rendered item</script>), tag
+    assert_match %(<script class="id">rendered item</script>), tag
   end
 end

--- a/test/helpers__asset_tags_test.rb
+++ b/test/helpers__asset_tags_test.rb
@@ -5,7 +5,7 @@ class HelpersAssetTagsTest < TestCase
     @renderer =
       QuickDummy.new(
         stylesheet_path: -> (basename) { "#{basename}.css" },
-        javascript_url: -> (basename) { "#{basename}.js" },
+        javascript_path: -> (basename) { "#{basename}.js" },
         stylesheets_root: -> { "stylesheets" },
         javascripts_root: -> { "javascripts" },
         items: -> { Hash.new("item".freeze) },

--- a/test/helpers__asset_tags_test.rb
+++ b/test/helpers__asset_tags_test.rb
@@ -18,19 +18,19 @@ class HelpersAssetTagsTest < TestCase
   def test_stylesheet_tag
     tag = @renderer.stylesheet_tag("foo", class: "id")
 
-    assert_match %(<link class="id" rel="stylesheet" href="foo.css" />), tag
+    assert_equal %(<link class="id" rel="stylesheet" href="foo.css" />), tag
   end
 
   def test_javascript_tag
     tag = @renderer.javascript_tag("foo", id: "class")
 
-    assert_match %(<script id="class" type="text/javascript" src="foo.js"></script>), tag
+    assert_equal %(<script id="class" type="text/javascript" src="foo.js"></script>), tag
   end
 
   test "overrideable stylesheet rel and href" do
     tag = @renderer.stylesheet_tag("foo", rel: "stylesheet/less", href: "bar.less")
 
-    assert_match %(<link rel="stylesheet/less" href="bar.less" />), tag
+    assert_equal %(<link rel="stylesheet/less" href="bar.less" />), tag
   end
 
   test "overrideable javascript type and src" do
@@ -42,12 +42,12 @@ class HelpersAssetTagsTest < TestCase
   def test_inline_stylesheet_tag
     tag = @renderer.inline_stylesheet_tag("foo", id: "class")
 
-    assert_match %(<style id="class">rendered item</style>), tag
+    assert_equal %(<style id="class">rendered item</style>), tag
   end
 
   def test_inline_javascript_tag
     tag = @renderer.inline_javascript_tag("foo", class: "id")
 
-    assert_match %(<script class="id">rendered item</script>), tag
+    assert_equal %(<script class="id">rendered item</script>), tag
   end
 end

--- a/test/helpers__asset_tags_test.rb
+++ b/test/helpers__asset_tags_test.rb
@@ -4,7 +4,7 @@ class HelpersAssetTagsTest < TestCase
   def setup
     @renderer =
       QuickDummy.new(
-        stylesheet_url: -> (basename) { "#{basename}.css" },
+        stylesheet_path: -> (basename) { "#{basename}.css" },
         javascript_url: -> (basename) { "#{basename}.js" },
         stylesheets_root: -> { "stylesheets" },
         javascripts_root: -> { "javascripts" },

--- a/test/helpers__asset_tags_test.rb
+++ b/test/helpers__asset_tags_test.rb
@@ -27,6 +27,18 @@ class HelpersAssetTagsTest < TestCase
     assert_match %(<script id="class" type="text/javascript" src="foo.js"></script>), tag
   end
 
+  test "overrideable stylesheet rel and href" do
+    tag = @renderer.stylesheet_tag("foo", rel: "stylesheet/less", href: "bar.less")
+
+    assert_match %(<link rel="stylesheet/less" href="bar.less" />), tag
+  end
+
+  test "overrideable javascript type and src" do
+    tag = @renderer.javascript_tag("foo", type: "text/coffeescript", src: "bar.coffee")
+
+    assert_equal %(<script type="text/coffeescript" src="bar.coffee"></script>), tag
+  end
+
   def test_inline_stylesheet_tag
     tag = @renderer.inline_stylesheet_tag("foo", id: "class")
 


### PR DESCRIPTION
- Fixes a bug where `*_url` methods were still being called
- Simplifies asserts in my tests
- Default to user given options (if a user does `stylesheet_url("style.css.less", rel: "stylesheet/less")`, the user specified value will take precedence)
