### PR TITLE
Nicer generator

### DIFF
--- a/lib/munge/cli/dispatch.rb
+++ b/lib/munge/cli/dispatch.rb
@@ -12,6 +12,10 @@ module Munge
       desc "init PATH", "Create new site at PATH"
       def init(path)
         directory ".", path
+
+        inside(path) do
+          run_bundle("install")
+        end
       end
 
       desc "build", "Build in current directory"
@@ -42,6 +46,14 @@ module Munge
 
       def symbolized_options
         Munge::Util::SymbolHash.deep_convert(options)
+      end
+
+      def run_bundle(command)
+        say_status :run, "bundle #{command}"
+
+        Bundler.with_clean_env do
+          system("bundle #{command}")
+        end
       end
     end
   end

--- a/lib/munge/cli/dispatch.rb
+++ b/lib/munge/cli/dispatch.rb
@@ -15,6 +15,7 @@ module Munge
 
         inside(path) do
           run_bundle("install")
+          run_bundle("binstub munge")
         end
       end
 

--- a/seeds/.gitignore
+++ b/seeds/.gitignore
@@ -1,0 +1,2 @@
+/dest
+/.sass-cache


### PR DESCRIPTION
On `munge init`:

- Generate a default `.gitignore` file
- Run `bundle install` and `bundle binstub munge`
