### PR TITLE
content_for :block

### DIFF
--- a/lib/munge/helpers/capture.rb
+++ b/lib/munge/helpers/capture.rb
@@ -27,6 +27,36 @@ module Munge
 
         text
       end
+
+      def yield_content(content_name, &block)
+        @content_fors ||= Hash.new([].freeze)
+
+        if @content_fors[content_name].empty?
+          if block_given?
+            inner = capture(&block)
+
+            append_to_erbout(block.binding, inner)
+          end
+        else
+          if block_given?
+            @content_fors[content_name].each do |content|
+              append_to_erbout(block.binding, content)
+            end
+          else
+            @content_fors[content_name].join("\n")
+          end
+        end
+      end
+
+      def content_for(content_name, &block)
+        @content_fors ||= Hash.new([].freeze)
+
+        if block_given?
+          inner = capture(&block)
+
+          @content_fors[content_name] += [inner]
+        end
+      end
     end
   end
 end

--- a/test/helpers__capture_test.rb
+++ b/test/helpers__capture_test.rb
@@ -27,6 +27,38 @@ class HelpersCaptureTest < TestCase
     refute_match("and you're cold", output)
   end
 
+  test "#yield_content with default and no replacement" do
+    template = extract_data("yield_content block layout")
+    erb      = ERB.new(template)
+    output   = erb.result(erb_context.get_binding)
+
+    assert_match("Default yield_content", output)
+  end
+
+  test "#yield_content with default and no block and no replacement" do
+    template = extract_data("yield_content nonblock layout")
+    erb      = ERB.new(template)
+    output   = erb.result(erb_context.get_binding)
+
+    assert_match(/^\s*$/, output)
+  end
+
+  test "#yield_content with a replacement" do
+    template = extract_data("content_for yield_content")
+    erb      = ERB.new(template)
+    output   = erb.result(erb_context.get_binding)
+
+    assert_match(/^\s*a\s*123\s*c\s*$/, output)
+  end
+
+  test "#yield_content with no block and with replacement" do
+    template = extract_data("content_for blank yield_content")
+    erb      = ERB.new(template)
+    output   = erb.result(erb_context.get_binding)
+
+    assert_match(/^\s*a\s*123\s*c\s*$/, output)
+  end
+
   private
 
   def erb_context
@@ -58,3 +90,35 @@ cause you're hot
 <% capture_test do %>
   Text
 <% end %>
+
+@@ yield_content block layout
+
+<% yield_content :test do %>
+Default yield_content
+<% end %>
+
+@@ yield_content nonblock layout
+
+<% yield_content :test %>
+
+@@ content_for yield_content
+
+<% content_for :test do %>
+123
+<% end %>
+
+a
+<% yield_content :test do %>
+b
+<% end %>
+c
+
+@@ content_for blank yield_content
+
+<% content_for :test do %>
+123
+<% end %>
+
+a
+<%= yield_content :test %>
+c

--- a/test/helpers__capture_test.rb
+++ b/test/helpers__capture_test.rb
@@ -1,27 +1,60 @@
 require "test_helper"
 
 class HelpersCaptureTest < TestCase
-  def test_find
-    helpers =
-      QuickDummy.new(
-        get_binding: -> { binding },
-        capture_test: lambda do |&block|
-          inner = capture(&block).upcase
-          append_to_erbout(block.binding, inner)
-        end
-      )
+  test "#append_to_erbout" do
+    helpers = erb_context
 
-    helpers.extend(Munge::Helpers::Capture)
+    helpers.define_singleton_method(:capture_test) do |&block|
+      inner = capture(&block).upcase
+      append_to_erbout(block.binding, inner)
+    end
 
-    template =
-      "<h1>hi</h1>\n" \
-      "<% capture_test do %>\n" \
-      "  Text\n" \
-      "<% end %>"
+    template = extract_data("append capture")
 
     erb    = ERB.new(template)
     output = erb.result(helpers.get_binding)
 
-    assert_equal "<h1>hi</h1>\n\n  TEXT\n", output
+    assert_equal("<h1>hi</h1>\n\n  TEXT\n\n", output)
+  end
+
+  test "#capture" do
+    template = extract_data("no output")
+
+    erb    = ERB.new(template)
+    output = erb.result(erb_context.get_binding)
+
+    assert_match("cause you're hot", output)
+    refute_match("and you're cold", output)
+  end
+
+  private
+
+  def erb_context
+    helpers =
+      QuickDummy.new(
+        get_binding: -> { binding },
+      )
+
+    helpers.extend(Munge::Helpers::Capture)
+
+    helpers
   end
 end
+
+__END__
+
+@@ no output
+
+cause you're hot
+
+<% capture do %>
+  and you're cold
+<% end %>
+
+
+@@ append capture
+
+<h1>hi</h1>
+<% capture_test do %>
+  Text
+<% end %>

--- a/test/support/extract_data.rb
+++ b/test/support/extract_data.rb
@@ -3,15 +3,26 @@ module ExtractData
     file     = caller_locations(1, 1).first.absolute_path
     contents = File.read(file)
     post_end = contents.split(/^__END__$/, 2).last || ""
-    matches  = post_end.strip.match(/(?:(@@\s*[^\n]*)\n([^(@@)]+)+)/m).to_a
     sections =
       post_end
         .split(/^@@\s*/)
         .map(&:rstrip)
-        .select { |s| s.length > 0 }
-        .map    { |section| section.split("\n", 2) }
+        .map { |section| section.split("\n", 2) }
+        .map { |key, value| [key, value] }
         .to_h
 
-    sections[name].sub(/^\n*/, "") + "\n"
+    found_section = sections[name]
+
+    if found_section.nil?
+      return nil
+    end
+
+    extracted_section = found_section.sub(/^\n*/, "")
+
+    if extracted_section[-1] == "\n"
+      extracted_section
+    else
+      extracted_section + "\n"
+    end
   end
 end

--- a/test/support/extract_data.rb
+++ b/test/support/extract_data.rb
@@ -1,0 +1,17 @@
+module ExtractData
+  def extract_data(name)
+    file     = caller_locations(1, 1).first.absolute_path
+    contents = File.read(file)
+    post_end = contents.split(/^__END__$/, 2).last || ""
+    matches  = post_end.strip.match(/(?:(@@\s*[^\n]*)\n([^(@@)]+)+)/m).to_a
+    sections =
+      post_end
+        .split(/^@@\s*/)
+        .map(&:rstrip)
+        .select { |s| s.length > 0 }
+        .map    { |section| section.split("\n", 2) }
+        .to_h
+
+    sections[name].sub(/^\n*/, "") + "\n"
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,6 +31,7 @@ require "securerandom"
 
 require_relative "support/declarative"
 require_relative "support/quick_dummy"
+require_relative "support/extract_data"
 
 require_relative "interfaces/command_interface_test"
 require_relative "interfaces/formatter_interface_test"
@@ -39,6 +40,7 @@ require_relative "interfaces/transformer_interface_test"
 
 class TestCase < Minitest::Test
   extend Declarative
+  include ExtractData
 
   def seeds_path
     File.absolute_path(File.expand_path("../../seeds", __FILE__))


### PR DESCRIPTION
This has been a feature I thought I should implement, but now that I have, I don't know if it's useful.

An alternative, manual solution would be the following:

``` erb
<!-- post.erb -->

<% @title = capture do %>
First post!
<% end %>

<p>Blog content etc.</p>

<!-- layout.erb -->

<head>
  <title><%= @title ? @title.strip : "My Cool Blog" %><title>
<head>
<body>
  <%= yield %>
</body>
```
