### PR TITLE
CLI Command to update configuration to latest

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - Gemfile
     - Rakefile
     - munge.gemspec
+    - sandbox/**/*
 
 Metrics/AbcSize:
   Exclude:

--- a/lib/munge/cli.rb
+++ b/lib/munge/cli.rb
@@ -5,6 +5,7 @@ require "munge/cli/commands/init"
 require "munge/cli/commands/build"
 require "munge/cli/commands/view"
 require "munge/cli/commands/server"
+require "munge/cli/commands/update"
 require "munge/cli/dispatch"
 
 require "munge/formatters/default"

--- a/lib/munge/cli/commands/update.rb
+++ b/lib/munge/cli/commands/update.rb
@@ -9,7 +9,7 @@ module Munge
           File.expand_path("../../../../../seeds", __FILE__)
         end
 
-        def initialize(bootloader, path)
+        def initialize(_bootloader, path)
           self.options = {}
           self.destination_root = File.expand_path(path)
         end

--- a/lib/munge/cli/commands/update.rb
+++ b/lib/munge/cli/commands/update.rb
@@ -1,0 +1,24 @@
+module Munge
+  module Cli
+    module Commands
+      class Update
+        include Thor::Base
+        include Thor::Actions
+
+        def self.source_root
+          File.expand_path("../../../../../seeds", __FILE__)
+        end
+
+        def initialize(bootloader, path)
+          self.options = {}
+          self.destination_root = File.expand_path(path)
+        end
+
+        def call
+          directory("config", File.expand_path("config", destination_root))
+          copy_file("setup.rb")
+        end
+      end
+    end
+  end
+end

--- a/lib/munge/cli/dispatch.rb
+++ b/lib/munge/cli/dispatch.rb
@@ -33,6 +33,13 @@ module Munge
         Commands::Server.new(bootloader).call
       end
 
+      desc "update", "Use with caution: override local configs with pristine version (useful after bumping version in Gemfile)"
+      def update
+        ENV["MUNGE_ENV"]  ||= "development"
+
+        Commands::Update.new(bootloader, current_working_directory).call
+      end
+
       desc "version", "Print version (v#{Munge::VERSION})"
       map %w(-v --version) => "version"
       def version

--- a/lib/munge/cli/dispatch.rb
+++ b/lib/munge/cli/dispatch.rb
@@ -33,7 +33,7 @@ module Munge
         Commands::Server.new(bootloader).call
       end
 
-      desc "version", "Print version"
+      desc "version", "Print version (v#{Munge::VERSION})"
       map %w(-v --version) => "version"
       def version
         puts "munge #{Munge::VERSION}"

--- a/lib/munge/cli/dispatch.rb
+++ b/lib/munge/cli/dispatch.rb
@@ -35,7 +35,7 @@ module Munge
 
       desc "update", "Use with caution: override local configs with pristine version (useful after bumping version in Gemfile)"
       def update
-        ENV["MUNGE_ENV"]  ||= "development"
+        ENV["MUNGE_ENV"] ||= "development"
 
         Commands::Update.new(bootloader, current_working_directory).call
       end


### PR DESCRIPTION
**Summary**

- Add `munge update` command, which overrides your local configs with the pristine ones from the gem
- Very similar to running `munge init` within a directory that already has munge installed in it
- Cannot undo; users must be cautious and only run after committing all changes into source control

**Why**

- Useful for when you update your munge version, and the munge configs have breaking changes