### PR TITLE
Crazy system change

### DIFF
--- a/lib/munge/helpers/find.rb
+++ b/lib/munge/helpers/find.rb
@@ -2,11 +2,11 @@ module Munge
   module Helpers
     module Find
       def items
-        @items
+        system.items
       end
 
       def layouts
-        @layouts
+        system.layouts
       end
     end
   end

--- a/lib/munge/helpers/link.rb
+++ b/lib/munge/helpers/link.rb
@@ -2,7 +2,7 @@ module Munge
   module Helpers
     module Link
       def path_to(item)
-        @router.route(item)
+        system.router.route(item)
       end
 
       def link_to(item, text = nil, opts = {})

--- a/lib/munge/helpers/rendering.rb
+++ b/lib/munge/helpers/rendering.rb
@@ -28,7 +28,7 @@ module Munge
         output =
           engines
             .inject(content) do |memo, engine|
-              options  = @tilt_options[engine]
+              options  = tilt_options[engine]
               template = engine.new(template_name, options) { memo }
 
               if inner
@@ -62,7 +62,7 @@ module Munge
 
       def merged_data(*data)
         hash_with_string_and_symbol_keys =
-          data.inject(@global_data) do |merged, datum|
+          data.inject(system.global_data) do |merged, datum|
             merged.merge(datum)
           end
 
@@ -74,7 +74,7 @@ module Munge
 
       def resolve_layout(item_or_string)
         if item_or_string.is_a?(String)
-          @layouts[item_or_string]
+          system.layouts[item_or_string]
         else
           item_or_string
         end

--- a/lib/munge/system.rb
+++ b/lib/munge/system.rb
@@ -49,5 +49,6 @@ module Munge
     attr_accessor :global_data
     attr_accessor :router
     attr_accessor :items
+    attr_accessor :layouts
   end
 end

--- a/lib/munge/transformers/tilt_transformer.rb
+++ b/lib/munge/transformers/tilt_transformer.rb
@@ -13,7 +13,6 @@ module Munge
 
       def call(item, content = nil, renderer = nil)
         scope = @pristine_scope.dup
-        scope.instance_variable_set(:@renderer, @renderer)
         dirty_scope = extend_with_helpers(scope)
         dirty_scope.instance_variable_set(:@tilt_options, @demands)
         dirty_scope.render_with_layout(item, content_engines: renderer, content_override: content)

--- a/lib/munge/transformers/tilt_transformer.rb
+++ b/lib/munge/transformers/tilt_transformer.rb
@@ -18,8 +18,6 @@ module Munge
         scope = Object.new
         @registry.each { |helpers| scope.extend(helpers) }
         scope.define_singleton_method(:system) { system }
-        scope.define_singleton_method(:layouts) { system.layouts }
-        scope.define_singleton_method(:items) { system.items }
         scope.define_singleton_method(:tilt_options) { demands }
 
         scope.render_with_layout(item, content_engines: renderer, content_override: content)

--- a/lib/munge/transformers/tilt_transformer.rb
+++ b/lib/munge/transformers/tilt_transformer.rb
@@ -12,13 +12,8 @@ module Munge
       end
 
       def call(item, content = nil, renderer = nil)
-        system = @system.clone
-        demands = @demands
-
-        scope = Object.new
+        scope = Scope.new(@system.clone, @demands)
         @registry.each { |helpers| scope.extend(helpers) }
-        scope.define_singleton_method(:system) { system }
-        scope.define_singleton_method(:tilt_options) { demands }
 
         scope.render_with_layout(item, content_engines: renderer, content_override: content)
       end
@@ -29,6 +24,16 @@ module Munge
 
       def demand(tilt_template, **options)
         @demands[tilt_template] = @demands[tilt_template].merge(options)
+      end
+
+      class Scope
+        def initialize(system, tilt_options)
+          @system = system
+          @tilt_options = tilt_options
+        end
+
+        attr_reader :system
+        attr_reader :tilt_options
       end
     end
   end

--- a/lib/munge/transformers/tilt_transformer.rb
+++ b/lib/munge/transformers/tilt_transformer.rb
@@ -12,7 +12,7 @@ module Munge
       end
 
       def call(item, content = nil, renderer = nil)
-        system = @system.dup
+        system = @system.clone
         demands = @demands
 
         scope = Object.new

--- a/test/helpers__find_test.rb
+++ b/test/helpers__find_test.rb
@@ -4,12 +4,15 @@ class HelpersFindTest < TestCase
   def setup
     items = { id: "item" }
 
+    system = Object.new
+    system.define_singleton_method(:items) { items }
+
     @renderer = Object.new
-    @renderer.instance_variable_set(:@items, items)
+    @renderer.define_singleton_method(:system) { system }
     @renderer.extend(Munge::Helpers::Find)
   end
 
-  def test_find
+  test "find" do
     item = @renderer.items[:id]
 
     assert_equal "item", item

--- a/test/helpers__find_test.rb
+++ b/test/helpers__find_test.rb
@@ -7,8 +7,7 @@ class HelpersFindTest < TestCase
     system = Object.new
     system.define_singleton_method(:items) { items }
 
-    @renderer = Object.new
-    @renderer.define_singleton_method(:system) { system }
+    @renderer = tilt_scope_class.new(system, {})
     @renderer.extend(Munge::Helpers::Find)
   end
 

--- a/test/helpers__link_test.rb
+++ b/test/helpers__link_test.rb
@@ -8,30 +8,33 @@ class HelpersLinkTest < TestCase
       "/super/cool"
     end
 
+    system = Object.new
+    system.define_singleton_method(:router) { dummy_router }
+
     @renderer = Object.new
-    @renderer.instance_variable_set(:@router, dummy_router)
+    @renderer.define_singleton_method(:system) { system }
     @renderer.extend(Munge::Helpers::Link)
   end
 
-  def test_path_to
+  test "#path_to" do
     url = @renderer.path_to(Object.new)
 
     assert_equal "/super/cool", url
   end
 
-  def test_link_to_with_custom_text
+  test "#link_to with custom text" do
     html = @renderer.link_to(Object.new, "custom text")
 
     assert_equal %(<a href="/super/cool">custom text</a>), html
   end
 
-  def test_link_to_without_custom_text
+  test "#link_to without custom text" do
     html = @renderer.link_to(Object.new)
 
     assert_equal %(<a href="/super/cool">/super/cool</a>), html
   end
 
-  def test_link_to_with_html_opts
+  test "#link_to with html options/attributes" do
     html = @renderer.link_to(Object.new, class: "hi", "asdf" => 3)
 
     assert_equal %(<a href="/super/cool" class="hi" asdf="3">/super/cool</a>), html

--- a/test/helpers__link_test.rb
+++ b/test/helpers__link_test.rb
@@ -11,8 +11,7 @@ class HelpersLinkTest < TestCase
     system = Object.new
     system.define_singleton_method(:router) { dummy_router }
 
-    @renderer = Object.new
-    @renderer.define_singleton_method(:system) { system }
+    @renderer = tilt_scope_class.new(system, {})
     @renderer.extend(Munge::Helpers::Link)
   end
 

--- a/test/helpers__rendering_test.rb
+++ b/test/helpers__rendering_test.rb
@@ -5,9 +5,7 @@ class HelpersRenderingTest < TestCase
     @system = system = Object.new
     @system.define_singleton_method(:global_data) { {} }
 
-    @renderer = Object.new
-    @renderer.define_singleton_method(:tilt_options) { {} }
-    @renderer.define_singleton_method(:system) { system }
+    @renderer = tilt_scope_class.new(system, {})
     @renderer.extend(Munge::Helpers::Rendering)
     @renderer.extend(Munge::Helpers::Find)
     @renderer.extend(Munge::Helpers::Capture)

--- a/test/helpers__rendering_test.rb
+++ b/test/helpers__rendering_test.rb
@@ -2,14 +2,18 @@ require "test_helper"
 
 class HelpersRenderingTest < TestCase
   def setup
+    @system = system = Object.new
+    @system.define_singleton_method(:global_data) { {} }
+
     @renderer = Object.new
-    @renderer.instance_variable_set(:@global_data, {})
-    @renderer.instance_variable_set(:@tilt_options, {})
+    @renderer.define_singleton_method(:tilt_options) { {} }
+    @renderer.define_singleton_method(:system) { system }
     @renderer.extend(Munge::Helpers::Rendering)
+    @renderer.extend(Munge::Helpers::Find)
     @renderer.extend(Munge::Helpers::Capture)
   end
 
-  def test_basic_render
+  test "#render with basic erb input" do
     item = OpenStruct.new
     item.content = %(<h1><%= "hi" %></h1>)
     item.frontmatter = {}
@@ -20,7 +24,7 @@ class HelpersRenderingTest < TestCase
     assert_equal "<h1>hi</h1>", output
   end
 
-  def test_render_with_content_override
+  test "#render with content_override" do
     item = OpenStruct.new
     item.content = %(<h1><%= "hi" %></h1>)
     item.frontmatter = {}
@@ -31,7 +35,7 @@ class HelpersRenderingTest < TestCase
     assert_equal "test", output
   end
 
-  def test_render_with_engine_override
+  test "#render with engine override" do
     item = OpenStruct.new
     item.content = %(<h1><%= "hi" %></h1>)
     item.frontmatter = {}
@@ -42,7 +46,7 @@ class HelpersRenderingTest < TestCase
     assert_equal %(<h1><%= "hi" %></h1>), output
   end
 
-  def test_render_with_array_engine_override
+  test "#render with list of engine overrides" do
     item = OpenStruct.new
     item.content = %(<h1><%= "hi" %></h1>)
     item.frontmatter = {}
@@ -53,7 +57,7 @@ class HelpersRenderingTest < TestCase
     assert_equal %(<h1>hi</h1>), output
   end
 
-  def test_layout_when_item_is_passed
+  test "#layout when item is passed" do
     layout = OpenStruct.new
     layout.content = %(<h1><%= yield %></h1>)
     layout.frontmatter = {}
@@ -65,7 +69,7 @@ class HelpersRenderingTest < TestCase
     assert_equal %(<h1><%= "hi" %></h1>), output
   end
 
-  def test_layout_when_string_is_passed
+  test "#layout when name of layout is passed" do
     layout = OpenStruct.new
     layout.content = %(<h1><%= yield %></h1>)
     layout.frontmatter = {}
@@ -73,14 +77,14 @@ class HelpersRenderingTest < TestCase
     layout.class = Munge::Item
     layout.id = "identifier"
 
-    @renderer.instance_variable_set(:@layouts, layout.id => layout)
+    @system.define_singleton_method(:layouts) { { layout.id => layout } }
 
     output = @renderer.layout("identifier") { %(<%= "hi" %>) }
 
     assert_equal %(<h1><%= "hi" %></h1>), output
   end
 
-  def test_layout_in_render
+  test "#layout nested in #render (#render #layout #render)" do
     layout = OpenStruct.new
     layout.content = %(<h1><%= yield %></h1>)
     layout.frontmatter = {}
@@ -89,7 +93,7 @@ class HelpersRenderingTest < TestCase
     layout.id = "identifier"
 
     outer = OpenStruct.new
-    outer.content = %(<div><%= layout("identifier") { render(@items["inner"]) } %></div>)
+    outer.content = %(<div><%= layout("identifier") { render(items["inner"]) } %></div>)
     outer.frontmatter = {}
     outer.relpath = "outer.erb"
     outer.id = "outer"
@@ -100,8 +104,8 @@ class HelpersRenderingTest < TestCase
     inner.relpath = "inner.erb"
     inner.id = "inner"
 
-    @renderer.instance_variable_set(:@layouts, layout.id => layout)
-    @renderer.instance_variable_set(:@items, inner.id => inner, outer.id => outer)
+    @system.define_singleton_method(:layouts) { { layout.id => layout } }
+    @system.define_singleton_method(:items) { { inner.id => inner, outer.id => outer } }
 
     output = @renderer.render(outer)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,4 +43,8 @@ class TestCase < Minitest::Test
   def seeds_path
     File.absolute_path(File.expand_path("../../seeds", __FILE__))
   end
+
+  def tilt_scope_class
+    Munge::Transformers::TiltTransformer::Scope
+  end
 end

--- a/test/transformers__tilt_transformer_test.rb
+++ b/test/transformers__tilt_transformer_test.rb
@@ -4,14 +4,11 @@ class TransformersTiltTransformerTest < TestCase
   include TransformerInterfaceTest
 
   def setup
-    fake_scope = Object.new
-    fake_scope.instance_variable_set(:@global_data, {})
-
-    @tilt_transformer = Munge::Transformers::TiltTransformer.new(fake_scope)
+    @tilt_transformer = transformer
     @tilt_transformer.register(Munge::Helpers::Rendering)
   end
 
-  def test_auto_transform
+  test "auto transform" do
     item = new_item
     item.relpath = "foo.erb"
     output = @tilt_transformer.call(item)
@@ -19,7 +16,7 @@ class TransformersTiltTransformerTest < TestCase
     assert_equal "hi", output
   end
 
-  def test_manual_transform
+  test "manual transform" do
     item = new_item
     item.relpath = "foo.txt"
     output = @tilt_transformer.call(item, nil, "erb")
@@ -46,7 +43,7 @@ class TransformersTiltTransformerTest < TestCase
 
   def transformer
     fake_scope = Object.new
-    fake_scope.instance_variable_set(:@global_data, {})
+    fake_scope.define_singleton_method(:global_data) { Hash.new }
 
     Munge::Transformers::TiltTransformer.new(fake_scope)
   end


### PR DESCRIPTION
Historically, I've been accessing instance variables in `Munge::System` in the view scope. This has always felt super messy to me.

This PR introduces the `system` variable/method into the rendering scope. The system variable will expose attribute readers, so all helpers have been updated to use these methods instead of instance variables.

(The change was a lot smaller than I originally anticipated 😄)